### PR TITLE
Make build green again by requiring securerandom

### DIFF
--- a/lib/viscacha/store.rb
+++ b/lib/viscacha/store.rb
@@ -91,7 +91,8 @@ module Viscacha
         delete_entry(key)
         return true if get_free_space > (bytes * 2) && get_free_ratio > 0.15
       end
-      return false
+
+      false
     end
 
     def touch_entry(entry, key)
@@ -117,7 +118,7 @@ module Viscacha
       compressed = (compressed == 1)
       expires_in = nil if expires_in == 0
 
-      ActiveSupport::Cache::Entry.create(data, created_at, compressed:compressed, expires_in:expires_in)
+      ActiveSupport::Cache::Entry.create(data, created_at, compressed: compressed, expires_in: expires_in)
     end
   end
 end

--- a/spec/viscacha/store_spec.rb
+++ b/spec/viscacha/store_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'viscacha/store'
 require 'pathname'
+require 'securerandom'
 
 describe Viscacha::Store do
   NAME = $$
@@ -43,7 +44,7 @@ describe Viscacha::Store do
       end
 
       it 'caches structured values' do
-        data = { foo:12.34, bar:56, qux:nil }
+        data = { foo: 12.34, bar: 56, qux: nil }
         subject.write('foo', data)
         subject.read('foo').should eq(data)
       end
@@ -83,7 +84,7 @@ describe Viscacha::Store do
       SecureRandom.random_bytes(size_mb.megabytes)
     end
 
-    subject { described_class.new directory:'tmp', name:$$, size:16.megabytes }
+    subject { described_class.new(directory: 'tmp', name: $$, size: 16.megabytes) }
     before  { subject.clear }
 
     it 'evicts items' do


### PR DESCRIPTION
Hi Julien

To make the build green again I just had to require `securerandom` 

https://ruby-doc.org/stdlib-2.2.0/libdoc/securerandom/rdoc/SecureRandom.html

Thanks

